### PR TITLE
Fix mixed version and channel displays in cbox

### DIFF
--- a/src/conan_app_launcher/__init__.py
+++ b/src/conan_app_launcher/__init__.py
@@ -1,7 +1,7 @@
 """
 Contains global constants and basic/ui variables.
 """
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 from pathlib import Path
 

--- a/src/conan_app_launcher/components/config_file.py
+++ b/src/conan_app_launcher/components/config_file.py
@@ -155,7 +155,7 @@ class AppEntry():
         self._executable = full_path
 
     @property
-    def icon(self):
+    def icon(self) -> Path:
         return self._icon
 
     @icon.setter
@@ -181,7 +181,7 @@ class AppEntry():
             self.app_data["icon"] = new_value
 
     @property
-    def is_console_application(self):
+    def is_console_application(self) -> bool:
         return bool(self.app_data.get("console_application"))
 
     @is_console_application.setter

--- a/src/conan_app_launcher/ui/layout_entries.py
+++ b/src/conan_app_launcher/ui/layout_entries.py
@@ -94,6 +94,12 @@ class AppUiEntry(QtWidgets.QVBoxLayout):
         if self._app_info.version == self._app_version_cbox.currentText():  # no change
             return
         self._app_button.grey_icon()
+        # update channels to match version
+        self._app_channel_cbox.clear()  # reset cbox
+        self._app_channel_cbox.addItems([self._app_info.INVALID_DESCR] + self._app_info.channels)
+        self._app_channel_cbox.setCurrentIndex(0)
+
+        self._app_info.channel = self._app_info.INVALID_DESCR
         self._app_info.version = self._app_version_cbox.currentText()
 
     def channel_selected(self, index):

--- a/test/unit/test_config_file.py
+++ b/test/unit/test_config_file.py
@@ -181,7 +181,8 @@ def testIconEval(base_fixture, capsys, tmp_path):
     # extract icon
     app.icon = ""
     if platform.system() == "Windows":
-        assert app.icon == Path(tempfile.gettempdir()) / (str(Path(sys.executable).name) + ".png")
+        icon_path = Path(tempfile.gettempdir()) / (str(Path(sys.executable).name) + ".png")
+        assert app.icon == icon_path.resolve()
     elif platform.system() == "Linux":
         assert app.icon == this.default_icon
 


### PR DESCRIPTION
Decouple mixed display of version and channels in combo boxes.
* only display channels matching the selected version
* on changing the version the channel resets to NA, so the user must select a valid channel, to avoid unwanted installation of a wrong channel 